### PR TITLE
Fixing the setBaselineName/setBaselineEnvName methods

### DIFF
--- a/src/EyesBase.js
+++ b/src/EyesBase.js
@@ -311,9 +311,9 @@
         this._logger.log("Baseline environment name: " + baselineName);
 
         if(!baselineName) {
-            this.baselineEnvName = null;
+            this._baselineEnvName = null;
         } else {
-            this.baselineEnvName = baselineName.trim();
+            this._baselineEnvName = baselineName.trim();
         }
     };
 
@@ -336,9 +336,9 @@
         this._logger.log("Baseline environment name: " + baselineEnvName);
 
         if(!baselineEnvName) {
-            this.baselineEnvName = null;
+            this._baselineEnvName = null;
         } else {
-            this.baselineEnvName = baselineEnvName.trim();
+            this._baselineEnvName = baselineEnvName.trim();
         }
     };
 


### PR DESCRIPTION
The above methods don't work currently because they are using `this.baseline` instead of `this._baseline` when setting a baseline name.