### PR TITLE
New fields ignoreCaret and compareWithParentBranch

### DIFF
--- a/src/EyesBase.js
+++ b/src/EyesBase.js
@@ -132,6 +132,7 @@
             this._logger = new Logger();
             this._serverUrl = serverUrl;
             this._defaultMatchSettings = new ImageMatchSettings(MatchLevel.Strict);
+            this._compareWithParentBranch = false;
             this._failureReport = EyesBase.FailureReport.OnClose;
             this._userInputs = [];
             this._saveNewTests = true;
@@ -528,8 +529,8 @@
         return this._defaultMatchSettings.getMatchLevel();
     };
 
+    //noinspection JSUnusedGlobalSymbols
     /**
-     *
      * @param {ImageMatchSettings} defaultMatchSettings The match settings for the session.
      */
     EyesBase.prototype.setDefaultMatchSettings = function (defaultMatchSettings) {
@@ -538,11 +539,26 @@
 
     //noinspection JSUnusedGlobalSymbols
     /**
-     *
      * @return {ImageMatchSettings} The match settings for the session.
      */
     EyesBase.prototype.getDefaultMatchSettings = function () {
         return this._defaultMatchSettings;
+    };
+
+    //noinspection JSUnusedGlobalSymbols
+    /**
+     * @return {boolean} The currently compareWithParentBranch value
+     */
+    EyesBase.prototype.isCompareWithParentBranch = function () {
+        return this._compareWithParentBranch;
+    };
+
+    //noinspection JSUnusedGlobalSymbols
+    /**
+     * @param {boolean} compareWithParentBranch New compareWithParentBranch value, default is false
+     */
+    EyesBase.prototype.setCompareWithParentBranch = function (compareWithParentBranch) {
+        this._compareWithParentBranch = compareWithParentBranch;
     };
 
     //noinspection JSUnusedGlobalSymbols
@@ -1008,7 +1024,7 @@
     }
 
     //noinspection JSUnusedGlobalSymbols
-    EyesBase.prototype.checkWindow = function (tag, ignoreMismatch, retryTimeout, regionProvider, ignoreRegions, floatingRegions) {
+    EyesBase.prototype.checkWindow = function (tag, ignoreMismatch, retryTimeout, regionProvider, ignoreCaret, ignoreRegions, floatingRegions) {
         ignoreMismatch = ignoreMismatch || false;
         tag = tag || '';
         retryTimeout = retryTimeout || -1;
@@ -1046,7 +1062,7 @@
 				.then(function () {
 					this._logger.verbose("EyesBase.checkWindow - calling matchWindowTask.matchWindow");
 					return this._matchWindowTask.matchWindow(this._userInputs, this._lastScreenshot, regionProvider, tag,
-						this._shouldMatchWindowRunOnceOnTimeout, ignoreMismatch, retryTimeout, ignoreRegions, floatingRegions)
+						this._shouldMatchWindowRunOnceOnTimeout, ignoreMismatch, retryTimeout, ignoreCaret, ignoreRegions, floatingRegions)
 				}.bind(this))
 				.then(function (result) {
 					this._logger.verbose("EyesBase.checkWindow - match window returned result.");
@@ -1221,6 +1237,7 @@
 				}
 				var defaultMatchSettings = {
 					matchLevel: this._defaultMatchSettings.getMatchLevel(),
+                    ignoreCaret: this._defaultMatchSettings.isIgnoreCaret(),
 					exact: exact
 				};
 				this._sessionStartInfo = {
@@ -1229,6 +1246,7 @@
 					scenarioIdOrName: this._testName,
 					batchInfo: testBatch,
                     baselineEnvName: this._baselineEnvName,
+                    compareWithParentBranch: this.isCompareWithParentBranch(),
                     environmentName: this._environmentName,
 					environment: appEnv,
 					defaultMatchSettings: defaultMatchSettings,

--- a/src/MatchSettings.js
+++ b/src/MatchSettings.js
@@ -132,23 +132,23 @@
         return this._matchThreshold;
     };
 
-
     /**
      * Encapsulates the match settings for a session.
      *
      * @param {MatchLevel} matchLevel The "strictness" level to use.
      * @param {ExactMatchSettings} [exact] Additional threshold parameters when the {@code Exact} match level is used.
+     * @param {boolean} [ignoreCaret]
      *
      * @constructor
      **/
-    function ImageMatchSettings(matchLevel, exact) {
+    function ImageMatchSettings(matchLevel, exact, ignoreCaret) {
         this._matchLevel = matchLevel;
         this._exact = exact || null;
+        this._ignoreCaret = ignoreCaret || true;
     }
 
     //noinspection JSUnusedGlobalSymbols
     /**
-     *
      * @return {MatchLevel} The match level to use.
      */
     ImageMatchSettings.prototype.getMatchLevel = function () {
@@ -157,7 +157,6 @@
 
     //noinspection JSUnusedGlobalSymbols
     /**
-     *
      * @param {MatchLevel} matchLevel The match level to use.
      */
     ImageMatchSettings.prototype.setMatchLevel = function (matchLevel) {
@@ -166,9 +165,7 @@
 
     //noinspection JSUnusedGlobalSymbols
     /**
-     *
-     * @return {ExactMatchSettings} The additional threshold parameters when the {@code Exact} match level is used,
-     *                              if any.
+     * @return {ExactMatchSettings} The additional threshold parameters when the {@code Exact} match level is used, if any.
      */
     ImageMatchSettings.prototype.getExact = function () {
         return this._exact;
@@ -176,12 +173,26 @@
 
     //noinspection JSUnusedGlobalSymbols
     /**
-     *
-     * @param {ExactMatchSettings|null} exact The additional threshold parameters when the {@code Exact} match level
-     *                                  is used.
+     * @param {ExactMatchSettings|null} exact The additional threshold parameters when the {@code Exact} match level is used.
      */
     ImageMatchSettings.prototype.setExact = function (exact) {
         this._exact = exact;
+    };
+
+    //noinspection JSUnusedGlobalSymbols
+    /**
+     * @return {boolean}
+     */
+    ImageMatchSettings.prototype.isIgnoreCaret = function () {
+        return this._ignoreCaret;
+    };
+
+    //noinspection JSUnusedGlobalSymbols
+    /**
+     * @param {boolean} ignoreCaret
+     */
+    ImageMatchSettings.prototype.setIgnoreCaret = function (ignoreCaret) {
+        this._ignoreCaret = ignoreCaret;
     };
 
     var MatchSettings = {};

--- a/src/MatchWindowTask.js
+++ b/src/MatchWindowTask.js
@@ -79,7 +79,7 @@
         resolve(this._matchResult);
     }
 
-    function _match(regionProvider, tag, ignoreMismatch, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve) {
+    function _match(regionProvider, tag, ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve) {
         this._logger.verbose('MatchWindowTask.matchWindow - _match calls for app output');
         return this._getAppOutput(regionProvider, lastScreenshot).then(function (appOutput) {
             this._logger.verbose('MatchWindowTask.matchWindow - _match retrieved app output');
@@ -92,6 +92,7 @@
                     name: tag,
                     userInputs: userInputs,
                     imageMatchSettings: {
+                        ignoreCaret: ignoreCaret,
                         ignore: ignoreRegions,
                         floating: floatingRegions
                     },
@@ -108,7 +109,7 @@
     }
 
     function _retryMatch(start, retryTimeout, regionProvider, tag, userInputs, lastScreenshot,
-                         ignoreMismatch, ignoreRegions, floatingRegions, screenshot, resolve) {
+                         ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, screenshot, resolve) {
         if ((new Date().getTime() - start) < retryTimeout) {
             this._logger.verbose('MatchWindowTask._retryMatch will retry');
             this._logger.verbose('MatchWindowTask._retryMatch calls for app output');
@@ -124,6 +125,7 @@
                         name: tag,
                         userInputs: userInputs,
                         imageMatchSettings: {
+                            ignoreCaret: ignoreCaret,
                             ignore: ignoreRegions,
                             floating: floatingRegions
                         },
@@ -146,7 +148,7 @@
                                 this._logger.verbose('MatchWindowTask.matchWindow -',
                                     '_retryMatch timeout passed -  retrying');
                                 return _retryMatch.call(this, start, retryTimeout, regionProvider, tag, userInputs, lastScreenshot,
-                                    ignoreMismatch, ignoreRegions, floatingRegions, screenshot, resolve);
+                                    ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, screenshot, resolve);
                             }.bind(this));
                         }
                         this._logger.verbose('MatchWindowTask.matchWindow -',
@@ -159,7 +161,7 @@
         if (!this._matchResult.asExpected) {
             // Try one last time...
             this._logger.verbose('MatchWindowTask.matchWindow - _retryMatch last attempt because we got failure');
-            return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
+            return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
         }
 
         this._logger.verbose('MatchWindowTask.matchWindow - _retryMatch no need for ',
@@ -168,7 +170,7 @@
     }
 
     MatchWindowTask.prototype.matchWindow = function (userInputs, lastScreenshot, regionProvider, tag, shouldRunOnceOnRetryTimeout,
-                                                      ignoreMismatch, retryTimeout, ignoreRegions, floatingRegions) {
+                                                      ignoreMismatch, retryTimeout, ignoreCaret, ignoreRegions, floatingRegions) {
 
         this._logger.verbose("MatchWindowTask.matchWindow called with shouldRunOnceOnRetryTimeout: ",
             shouldRunOnceOnRetryTimeout, ", ignoreMismatch:", ignoreMismatch, ", retryTimeout:", retryTimeout);
@@ -184,17 +186,17 @@
                     this._logger.verbose('MatchWindowTask.matchWindow - running once but after going into timeout');
                     return this._waitTimeout(retryTimeout).then(function () {
                         this._logger.verbose('MatchWindowTask.matchWindow - back from timeout - calling match');
-                        return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
+                        return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
                     }.bind(this));
                 }
                 this._logger.verbose('MatchWindowTask.matchWindow - running once immediately');
-                return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
+                return _match.call(this, regionProvider, tag, ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, userInputs, lastScreenshot, resolve);
             }
             // Retry matching and ignore mismatches while the retry timeout does not expires.
             var start = new Date().getTime();
             this._logger.verbose('MatchWindowTask.matchWindow - starting retry sequence. start:', start);
             return _retryMatch.call(this, start, retryTimeout, regionProvider, tag, userInputs, lastScreenshot,
-                ignoreMismatch, ignoreRegions, floatingRegions, undefined, resolve);
+                ignoreMismatch, ignoreCaret, ignoreRegions, floatingRegions, undefined, resolve);
         }.bind(this));
     };
 


### PR DESCRIPTION
- Added 'ignoreCaret' field as part of defautImageMatchSettings and parameter of checkWindow method
- Added 'compareWithParentBranch' field in EyesBase (used in startSession)