### PR TITLE
default missing query to empty string

### DIFF
--- a/packages/eyes.sdk/src/ServerConnector.js
+++ b/packages/eyes.sdk/src/ServerConnector.js
@@ -412,7 +412,7 @@
                         reasonMsg += ` (${err.response.statusMessage})`;
                     }
 
-                    that._logger.log(`ServerConnector.${name} - ${method} failed on ${uri}: ${reasonMsg} with params ${JSON.stringify(options.query).slice(0, 100)}`);
+                    that._logger.log(`ServerConnector.${name} - ${method} failed on ${uri}: ${reasonMsg} with params ${(JSON.stringify(options.query) || '').slice(0, 100)}`);
                     that._logger.verbose(`ServerConnector.${name} - failure body:\n${err.response && err.response.data}`);
 
                     if (retry > 0 && ((err.response && HTTP_FAILED_CODES.includes(err.response.status)) || REQUEST_FAILED_CODES.includes(err.code))) {


### PR DESCRIPTION
When running `MatchWindow`
https://github.com/applitools/Eyes.Sdk.JavaScript/blob/3a94a13bc2015bce25998193564ac4092c8139b7/packages/eyes.sdk/src/ServerConnector.js#L247
`SendRequest` is invoked with `options.query` `undefined` which makes the error reporting crash when the request is failing
https://github.com/applitools/Eyes.Sdk.JavaScript/blob/3a94a13bc2015bce25998193564ac4092c8139b7/packages/eyes.sdk/src/ServerConnector.js#L415